### PR TITLE
Remove ":" from pt timestamps

### DIFF
--- a/dictionaries/pt/locale.yml
+++ b/dictionaries/pt/locale.yml
@@ -120,5 +120,5 @@ pt:
       long: "%A, %d de %B de %Y, %H:%Mh"
       reporting: "%Y-%m-%d %Hh%Mmin"
       short: "%d/%m, %H:%M hs"
-      wiki_time: "%Hh:%Mmin de %-d de %B de %Y (UTC)"
+      wiki_time: "%Hh%Mmin de %-d de %B de %Y (UTC)"
     pm: pm


### PR DESCRIPTION
This makes it consistent with MediaWiki signatures. Eg,:
https://pt.wikipedia.org/w/index.php?diff=44869362
shows `mb-date=12h:47min de 11 de fevereiro de 2016 (UTC)` but it should be `mb-date=12h47min de 11 de fevereiro de 2016 (UTC)`